### PR TITLE
Proposed feature: make profile:build and profile:host optional

### DIFF
--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -27,7 +27,15 @@ export class Commands{
         let buildFolder = this.addRootFolder(argument.installFolder);
         let installArg = argument.installArguments;
         let profile = argument.installProfile;
-        let profileCommand = `--profile:build ${profile.build} --profile:host ${profile.host}`; 
+        let profileCommand:string = "";
+        if (${profile.build})
+        {
+            profileCommand = profileCommand + ` --profile:build ${profile.build}`;
+        }
+        if (${profile.host})
+        {
+            profileCommand = profileCommand + ` --profile:host ${profile.host}`;
+        }
         let installFolderArg = `--install-folder ${buildFolder}`;
         const stringCommand = `${installCommand} ${profileCommand} ${installArg} ${installFolderArg} ${conanfile}`;
         let command = { executionCommand: stringCommand, description: "installing" };


### PR DESCRIPTION
I've never written typescript before so this could use a check. But: I've tried to make it so that the profileCommand only adds build or host profile if the argument is defined. This is so that you can use the cmake generator for Conan in Conan 1.x (if you specify both, that particular generator breaks).

Closes #183 